### PR TITLE
Structural variants: mateName for fusions

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -113,17 +113,22 @@ paths:
             type: string
             pattern: '^([ACGT]+|N)$'
         - name: variantType
-          description: >
+          description: |
             The `variantType` is used to denote e.g. structural variants.
-
-            Examples:
-
-            * DUP: duplication of sequence following `start`; not necessarily in
-            situ
-
-            * DEL: deletion of sequence following `start`
-
-
+            Examples:           
+            * DUP 
+                * duplication of sequence following `start` or beginning 
+                  in the `startMin` => `startMax` interval and ending at `end`
+                  or in the `endMin` => `endMax` interval; not necessarily in situ
+            * DEL
+                * deletion of sequence following `start` or beginning 
+                  in the `startMin` => `startMax` interval and ending at `end`
+                  or in the `endMin` => `endMax` interval; not necessarily in situ
+            * BND
+                * breakend, i.e. termination of the allele at position
+                  `start` or in the `startMin` => `startMax` interval, or fusion
+                  of the sequence to distant partner; TBD: fusion events need second
+                  `referenceName` attribute
             Optional: either `alternateBases` or `variantType` is required.
           in: query
           required: false

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -66,6 +66,17 @@ paths:
           in: query
           schema:
             type: string
+        - name: mateName
+          description: |
+            Second chromosome for fusion events. This can be
+            * empty (no fusion or unknown partner)
+            * identical to `referenceName` (e.g. one side of an inversion)
+            * a different chromosome
+            Accepting values 1-22, X, Y.
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Chromosome'
         - name: end
           description: |
             Precise end coordinate. See start.
@@ -115,13 +126,13 @@ paths:
         - name: variantType
           description: |
             The `variantType` is used to denote e.g. structural variants.
-            Examples:           
-            * DUP 
-                * duplication of sequence following `start` or beginning 
+            Examples:
+            * DUP
+                * duplication of sequence following `start` or beginning
                   in the `startMin` => `startMax` interval and ending at `end`
                   or in the `endMin` => `endMax` interval; not necessarily in situ
             * DEL
-                * deletion of sequence following `start` or beginning 
+                * deletion of sequence following `start` or beginning
                   in the `startMin` => `startMax` interval and ending at `end`
                   or in the `endMin` => `endMax` interval; not necessarily in situ
             * BND
@@ -155,7 +166,6 @@ paths:
             Indicator of whether responses for individual datasets
             (datasetAlleleResponses) should be included in the response
             (BeaconAlleleResponse) to this request or not.
-
             If null (not specified), the default value of NONE is assumed.
           in: query
           required: false
@@ -366,6 +376,8 @@ components:
         startMax:
           description: Maximum start coordinate. See startMin.
           type: integer
+        mateName:
+          $ref: '#/components/schemas/Chromosome'
         endMin:
           description: Minimum end coordinate. See startMin.
           type: integer
@@ -393,13 +405,13 @@ components:
         variantType:
           description: |
             The `variantType` is used to denote e.g. structural variants.
-            Examples:           
-            * DUP 
-                * duplication of sequence following `start` or beginning 
+            Examples:
+            * DUP
+                * duplication of sequence following `start` or beginning
                   in the `startMin` => `startMax` interval and ending at `end`
                   or in the `endMin` => `endMax` interval; not necessarily in situ
             * DEL
-                * deletion of sequence following `start` or beginning 
+                * deletion of sequence following `start` or beginning
                   in the `startMin` => `startMax` interval and ending at `end`
                   or in the `endMin` => `endMax` interval; not necessarily in situ
             * BND

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -127,8 +127,7 @@ paths:
             * BND
                 * breakend, i.e. termination of the allele at position
                   `start` or in the `startMin` => `startMax` interval, or fusion
-                  of the sequence to distant partner; TBD: fusion events need second
-                  `referenceName` attribute
+                  of the sequence to distant partner
             Optional: either `alternateBases` or `variantType` is required.
           in: query
           required: false
@@ -392,17 +391,21 @@ components:
           type: string
           pattern: '^([ACGT]+|N)$'
         variantType:
-          description: >
+          description: |
             The `variantType` is used to denote e.g. structural variants.
-
-            Examples:
-
-            * DUP: duplication of sequence following `start`; not necessarily in
-            situ
-
-            * DEL: deletion of sequence following `start`
-
-
+            Examples:           
+            * DUP 
+                * duplication of sequence following `start` or beginning 
+                  in the `startMin` => `startMax` interval and ending at `end`
+                  or in the `endMin` => `endMax` interval; not necessarily in situ
+            * DEL
+                * deletion of sequence following `start` or beginning 
+                  in the `startMin` => `startMax` interval and ending at `end`
+                  or in the `endMin` => `endMax` interval; not necessarily in situ
+            * BND
+                * breakend, i.e. termination of the allele at position
+                  `start` or in the `startMin` => `startMax` interval, or fusion
+                  of the sequence to distant partner
             Optional: either `alternateBases` or `variantType` is required.
           type: string
         assemblyId:


### PR DESCRIPTION
This PR:

* adds a `mateName` attribute to `BeaconAlleleRequest`, to allow for the query of fusion events using the "BND" `variantType`
*  extends the inline documentation for variantType for the "BND" instance
* changes some of the multiline documentation style from YAML "Folded style" to "Literal Style" 

The naming of the attribute as `mateName` is open for changes. Some further documentation is probably needed (e.g. if `mateName` defined, it is always to be associated with the `end` | `endMin` + `endMax` values ...<sup>*</sup>).

<sup>*</sup>One may argue that the `end` position always has an associated chromosome, which is equal to `referenceName` if no `mateName` is specified