### PR TITLE
Fix info key

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -341,8 +341,8 @@ components:
           description: 'Additional unspecified metadata about the Beacon service.'
           type: object
           example:
-            beaconNetwork: ELIXIR Europe
-            dataCatalogue: ['Rare diseases', 'Twins']
+            additionalInfoKey1: additionalInfoValue1
+            additionalInfoKey2: [ additionalInfoValue2, additionalInfoValue3]
     BeaconAlleleRequest:
       description: Allele request as interpreted by the beacon.
       type: object
@@ -506,7 +506,7 @@ components:
           description: 'Additional unspecified metadata about the host Organization.'
           type: object
           example:
-            affiliation: ELIXIR Europe
+            additionalInfoKey: additionalInfoValue
     BeaconDataset:
       type: object
       required:
@@ -565,9 +565,8 @@ components:
           description: 'Additional unspecified metadata about the dataset.'
           type: object
           example:
-            fileTypes: ['.bam', '.vcf']
-            minReadDepth: 30
-            minQuality: 100
+            additionalInfoKey1: [ additionalInfoValue1, additionalInfoValue2]
+            additionalInfoKey2: additionalInfoValue3
         dataUseConditions:
           $ref: '#/components/schemas/DataUseConditions'
     BeaconDatasetAlleleResponse:
@@ -615,10 +614,10 @@ components:
             URL to an external system, such as a secured beacon or a system
             providing more information about a given allele (RFC 3986 format).
         info:
-          description: 'Additional metadata about the response.'
+          description: 'Additional unspecified metadata about the response or its content.'
           type: object
           example:
-            additionalVariants: true
+            additionalInfoKey: additionalInfoValue
     BeaconError:
       description: >-
         Beacon-specific error. This should be non-null in exceptional situations

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 servers: []
 info:
-  version: "1.0.1"
+  version: "1.1.0"
   title: GA4GH Beacon API Specification
   description: >-
     A Beacon is a web service for genetic data sharing that can be queried for information about specific alleles.
@@ -338,10 +338,11 @@ components:
           items:
             $ref: '#/components/schemas/BeaconAlleleRequest'
         info:
-          description: 'Additional structured metadata, key-value pairs.'
-          type: array
-          items:
-            $ref: '#/components/schemas/KeyValuePair'
+          description: 'Additional unspecified metadata about the Beacon service.'
+          type: object
+          example:
+            beaconNetwork: ELIXIR Europe
+            dataCatalogue: ['Rare diseases', 'Twins']
     BeaconAlleleRequest:
       description: Allele request as interpreted by the beacon.
       type: object
@@ -502,10 +503,10 @@ components:
             URL to the logo (PNG/JPG format) of the organization (RFC 3986
             format).
         info:
-          description: 'Additional structured metadata, key-value pairs.'
-          type: array
-          items:
-            $ref: '#/components/schemas/KeyValuePair'
+          description: 'Additional unspecified metadata about the host Organization.'
+          type: object
+          example:
+            affiliation: ELIXIR Europe
     BeaconDataset:
       type: object
       required:
@@ -561,10 +562,12 @@ components:
             3986 format).
           example: 'http://example.org/wiki/Main_Page'
         info:
-          description: 'Additional structured metadata, key-value pairs.'
-          type: array
-          items:
-            $ref: '#/components/schemas/KeyValuePair'
+          description: 'Additional unspecified metadata about the dataset.'
+          type: object
+          example:
+            fileTypes: ['.bam', '.vcf']
+            minReadDepth: 30
+            minQuality: 100
         dataUseConditions:
           $ref: '#/components/schemas/DataUseConditions'
     BeaconDatasetAlleleResponse:
@@ -612,10 +615,10 @@ components:
             URL to an external system, such as a secured beacon or a system
             providing more information about a given allele (RFC 3986 format).
         info:
-          description: 'Additional structured metadata, key-value pairs.'
-          type: array
-          items:
-            $ref: '#/components/schemas/KeyValuePair'
+          description: 'Additional metadata about the response.'
+          type: object
+          example:
+            additionalVariants: true
     BeaconError:
       description: >-
         Beacon-specific error. This should be non-null in exceptional situations
@@ -629,16 +632,6 @@ components:
           format: int32
           example: 'same as HTTP status code'
         errorMessage:
-          type: string
-    KeyValuePair:
-      type: object
-      required:
-        - key
-        - value
-      properties:
-        key:
-          type: string
-        value:
           type: string
     DataUseConditions:
       type: object


### PR DESCRIPTION
Fixes #168 
This was attempted at https://github.com/ga4gh-beacon/specification/pull/197 but was closed

This change introduces a solution to fix the issue with the `info` key and `KeyValuePair`, by conforming to [JSON standards](https://www.json.org/), in plain terms: `info`'s value would be of type object.

An example of how this might look in practice is provided by @blankdots at https://github.com/ga4gh-beacon/specification/issues/223#issuecomment-434187861

This PR builds on top of https://github.com/ga4gh-beacon/specification/pull/225 as it has the change made to `.travis.yml`.