### PR TITLE
Update contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ The way to contribute development effort and code to the project is via GitHub p
 
 Some general rules to follow:
 
--   [Fork](https://help.github.com/articles/fork-a-repo) the main project into your personal GitHub space to work on.
 -   Create a branch for each update that you're working on. These branches are often called "feature" or "topic" branches. Any changes that you push to your feature branch will automatically be shown in the pull request.
 -   Keep your pull requests as small as possible. Large pull requests are hard to review. Try to break up your changes into self-contained and incremental pull requests.
 -   The first line of commit messages should be a short (&lt;80 character) summary, followed by an empty line and then any details that you want to share about the commit.


### PR DESCRIPTION
The contribution guidelines have a misstatement of making pull requests from forked repositories. This line should be removed, as it does not reflect the reality. The `.travis.yml` configuration file at https://github.com/ga4gh-beacon/specification/blob/master/.travis.yml requires pull requests to be made from the main repository https://github.com/ga4gh-beacon/specification. In other cases Travis builds will fail.

As this information is relevant for new contributors, I believe the merge can go directly into master, bypassing the develop -branch.