### PR TITLE
Update logoUrl

### DIFF
--- a/beacon.md
+++ b/beacon.md
@@ -117,7 +117,7 @@ Beacon API SHOULD support cross-origin resource sharing (CORS) and follow [GA4GH
 |address|Address of the organization.|string|-|
 |welcomeUrl|URL of the website of the organization (RFC 3986 format).|string|-|
 |contactUrl|URL with the contact for the beacon operator/maintainer, e.g. link to a contact form (RFC 3986 format) or an email (RFC 2368 format).|string|-|
-|logoUrl|URL to the logo (PNG/JPG format) of the organization (RFC 3986 format).|string|-|
+|logoUrl|URL to the logo (PNG/JPG/SVG format) of the organization (RFC 3986 format).|string|-|
 |info|Additional structured metadata, key-value pairs.|string|-|
 
 **Beacon Dataset object**

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -505,7 +505,7 @@ components:
         logoUrl:
           type: string
           description: >-
-            URL to the logo (PNG/JPG format) of the organization (RFC 3986
+            URL to the logo (PNG/JPG/SVG format) of the organization (RFC 3986
             format).
         info:
           description: 'Additional unspecified metadata about the host Organization.'


### PR DESCRIPTION
`logoUrl` currently states, that the image should be of format PNG or JPG. This should be extended to include SVG which is a well established web standard, and **the** preferred format of using images on the web.

https://www.w3.org/TR/SVG2/