### PR TITLE
Added objects and fields descriptions

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -351,7 +351,7 @@ components:
             additionalInfoKey1: additionalInfoValue1
             additionalInfoKey2: [ additionalInfoValue2, additionalInfoValue3]
     BeaconAlleleRequest:
-      description: Allele request as interpreted by the beacon.
+      description: Allele request made against the beacon. The allele must be mapped against a sequence in a genome, and a range can be optionally specified.
       type: object
       required:
         - referenceName
@@ -447,6 +447,7 @@ components:
             - MISS
             - NONE
     BeaconAlleleResponse:
+      description: Response to a query for information about an allele, made against the beacon.
       type: object
       required:
         - beaconId
@@ -524,6 +525,7 @@ components:
           example:
             additionalInfoKey: additionalInfoValue
     BeaconDataset:
+      description: A dataset available in the beacon.
       type: object
       required:
         - id
@@ -586,6 +588,7 @@ components:
         dataUseConditions:
           $ref: '#/components/schemas/DataUseConditions'
     BeaconDatasetAlleleResponse:
+      description: Response containing information about an allele in a particular dataset.
       type: object
       required:
         - datasetId

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -612,17 +612,17 @@ components:
         variantCount:
           type: integer
           format: int64
-          description: Number of variants matching the allele request in the dataset.
+          description: Number of times the requested allele has been observed in the dataset.
           minimum: 0
         callCount:
           type: integer
           format: int64
-          description: Number of calls matching the allele request in the dataset.
+          description: Total number of calls in the dataset. Missing calls are not included.
           minimum: 0
         sampleCount:
           type: integer
           format: int64
-          description: Number of samples matching the allele request in the dataset
+          description: Number of samples in the dataset where the requested allele is found.
           minimum: 0
         note:
           type: string

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -283,6 +283,7 @@ components:
         - 'Y'
         - 'MT'
     Beacon:
+      description: Metadata describing a beacon instance.
       type: object
       required:
         - id


### PR DESCRIPTION
Following the Beacon implementation my team just developed, there were some classes and fields that could welcome extending the documentation.

I am aware the counts are already being discussed in #258 but this PR proposed an alternative description based on [this wiki page](https://github.com/ga4gh-beacon/specification/wiki/Calculating-counters-in-BeaconDatasetAlleleResponse), and it only applies to the `BeaconDatasetAlleleResponse` objects.