### PR TITLE
mentioning range matches for start + end

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -44,7 +44,7 @@ paths:
               - typical use are queries for SNV and small InDels
               - the use of "start" without an "end" parameter requires the use of "referenceBases"
             * start and end:
-              - special use case for exactly determined structural changes
+              - special use case for exactly determined structural changes or range matches
           in: query
           required: false
           schema:
@@ -55,7 +55,7 @@ paths:
           description: |
             Minimum start coordinate
             * startMin + startMax + endMin + endMax
-              - for querying imprecise positions (e.g. identifying all structural variants starting anywhere between startMin <-> startMax, and ending anywhere between endMin <-> endMax)
+              - for querying imprecise positions (e.g. identifying all specified SNVs or structural variants starting anywhere between startMin <-> startMax, and ending anywhere between endMin <-> endMax)
               - single or double sided precise matches can be achieved by setting startMin = startMax XOR endMin = endMax
           in: query
           schema:
@@ -367,7 +367,7 @@ components:
               - typical use are queries for SNV and small InDels
               - the use of "start" without an "end" parameter requires the use of "referenceBases"
             * start and end:
-              - special use case for exactly determined structural changes
+              - special use case for exactly determined structural changes or range matches
           type: integer
           format: int64
           minimum: 0
@@ -378,7 +378,7 @@ components:
           description: |
             Minimum start coordinate
             * startMin + startMax + endMin + endMax
-              - for querying imprecise positions (e.g. identifying all structural variants starting anywhere between startMin <-> startMax, and ending anywhere between endMin <-> endMax)
+              - for querying imprecise positions (e.g. identifying all specified SNVs or structural variants starting anywhere between startMin <-> startMax, and ending anywhere between endMin <-> endMax)
               - single or double sided precise matches can be achieved by setting startMin = startMax XOR endMin = endMax
           type: integer
         startMax:


### PR DESCRIPTION
While we have shown range matches and wildcards in demonstrations, so far the `start` + `end` documentation only mentions structural changes. This has been extended.